### PR TITLE
LBUpdateURL should be correctly encoded in Info.plist

### DIFF
--- a/Updates.lbaction/Contents/Scripts/updates.js
+++ b/Updates.lbaction/Contents/Scripts/updates.js
@@ -119,7 +119,6 @@ function checkAction(actionsDir, actionPackage) {
       ,children: getActionChildren(actionFile, plist, null)};
   }
 
-  updateURL = encodeURI(updateURL);
   LaunchBar.debugLog(actionPackage + ' URL ' + updateURL);
 
   var result = {};


### PR DESCRIPTION
I would suggest that LBUpdateURL keys should be saved correctly encoded in the action's Info.plist.
