### PR TITLE
Fixed LaunchBar update check

### DIFF
--- a/Updates.lbaction/Contents/Scripts/updates.js
+++ b/Updates.lbaction/Contents/Scripts/updates.js
@@ -278,7 +278,7 @@ function checkLaunchBar() {
         ,'icon':ALERT_ICON
         ,'url':LB_INFO};
     }
-    if (result.data[0].BundleVersion && result.data[0].BundleVersion != LaunchBar.version) {
+    if (result.data[0].BundleVersion && result.data[0].BundleVersion > LaunchBar.version) {
       return {'title':'LaunchBar: Newer version available   ' 
           + LaunchBar.shortVersion + ' ➔ ' + result.data[0].BundleShortVersionString
         ,'icon':CAUTION


### PR DESCRIPTION
A newer LaunchBar version was reported every time the version was not equal to the currently running one.
