### PR TITLE
Prevent removal of trailing spaces in device names

### DIFF
--- a/Switch Audio.lbaction/Contents/Scripts/audio.sh
+++ b/Switch Audio.lbaction/Contents/Scripts/audio.sh
@@ -16,6 +16,7 @@ fi
 CINPUT=`$CMD -c -t input`
 COUTPUT=`$CMD -c -t output`
 
+IFS=''
 while read -r INPUT
 do
   if [ ! -z "${INS}" ]


### PR DESCRIPTION
bash read was incorrectly removing significant leading or trailing
spaces from device audio names. This change preserves spaces, so that
device names round-tripped through this action will still be recognized
by SwitchAudioSource.

Fixes #13.