### PR TITLE
fix: SwitchAudioSource path on Apple Silicon

### DIFF
--- a/Switch Audio.lbaction/Contents/Scripts/audio.sh
+++ b/Switch Audio.lbaction/Contents/Scripts/audio.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-CMD=/usr/local/bin/SwitchAudioSource
+if [[ `uname -m` == 'arm64' ]]; then
+  CMD=/opt/homebrew/bin/SwitchAudioSource
+else
+  CMD=/usr/local/bin/SwitchAudioSource
+fi
 
 if [ ! -f "$CMD" ]
 then


### PR DESCRIPTION
According to [Homebrew](https://github.com/prenagha/launchbar/issues/16):

> This script installs Homebrew to its preferred prefix (/usr/local for macOS Intel, /opt/homebrew for Apple Silicon)

So the default path of homebrew-installed packages should be changed to `/opt/homebrew/bin/` on Apple Silicon Mac.