### PR TITLE
Update jira.js to support any Jira project

### DIFF
--- a/JIRA.lbaction/Contents/Scripts/jira.js
+++ b/JIRA.lbaction/Contents/Scripts/jira.js
@@ -9,9 +9,8 @@ function run(arg) {
     Action.preferences.crucibleBase = "https://crucible.example.com";
     
   var url = "";
-  if (arg.match(/^\d+$/)) {
-    url = Action.preferences.jiraBase + "/browse/ER-" + arg;
-  } else if (arg.match(/^ER-\d+$/i)) {
+
+  if (arg.match(/[A-Z]{2,}-\d+/i)) {
     url = Action.preferences.jiraBase + "/browse/" + arg;
   } else if (arg.match(/^CR-\d+$/i)) {
     url = Action.preferences.crucibleBase + "/cru/" + arg;


### PR DESCRIPTION
The current jira.js implementation was hardcoded with lookup for ER base, which was unnecessary. There was also behavior where the existing regex for issues without the ER project were being skipped. This solves for both conditions, while still moving to a search properly if a non-issue type is provided.