### PR TITLE
Use curl -w to output terminal URL

### DIFF
--- a/Expand URL.lbaction/Contents/Scripts/resolve.sh
+++ b/Expand URL.lbaction/Contents/Scripts/resolve.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # original idea from https://gist.github.com/Zettt/88ef3112c04ebecf475b
-EXP=`curl -siL "$1" | grep -i ^Location | grep -i http | tail -n 1 | cut -c 11- | tr -d '\n' | tr -d '\r'`
+EXP=`curl -siL -w '%{url_effective}' -o /dev/null "$1"`
 if [ -z "$EXP" ]
 then
   echo "$1"


### PR DESCRIPTION
`curl` has a built-in option for printing the terminal URL in a chain of redirects, which saves you having to parse the output manually--but feel free to ignore this PR…